### PR TITLE
Change master branch name to main

### DIFF
--- a/.github/workflows/healthcheck-loc.yml
+++ b/.github/workflows/healthcheck-loc.yml
@@ -2,9 +2,9 @@ name: healtcheck-loc
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:


### PR DESCRIPTION
GitHub changed the default branch name from `master` to `main` for new repositories (see [this post](https://github.com/github/renaming#renaming-the-default-branch-from-master)).

The `healthcheck-loc-action` should consider this too.

Do we need to update our bot which creates a PR for new repositories too?